### PR TITLE
[LA-87] Add private git repo support for eb extensions cloud-lrs deployment

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -16,7 +16,7 @@ option_settings:
     Application Healthcheck URL: HTTPS:443/
 
   aws:elasticbeanstalk:container:nodejs:
-    NodeVersion: 6.9.1
+    NodeVersion: 6.10.0
     ProxyServer: apache
     NodeCommand: 'node app'
 

--- a/.ebextensions/01_private_git_setup.config
+++ b/.ebextensions/01_private_git_setup.config
@@ -1,0 +1,17 @@
+files:
+  "/root/.ssh/github-eb-key":
+    authentication: S3Auth
+    mode: "000600"
+    owner: root
+    group: root
+    source: "https://s3-us-west-2.amazonaws.com/elasticbeanstalk-us-west-2-697877139013/cloud-lrs/github_eb_key"
+  "/root/.ssh/config":
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      Host github.com
+      IdentityFile /root/.ssh/github-eb-key
+      IdentitiesOnly yes
+      UserKnownHostsFile=/dev/null
+      StrictHostKeyChecking no

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,6 @@ var es = require('event-stream');
 var filter = require('gulp-filter');
 var fs = require('fs');
 var gulp = require('gulp');
-var imagemin = require('gulp-imagemin');
 var eslint = require('gulp-eslint');
 var minifyHtml = require('gulp-htmlmin');
 var mocha = require('gulp-mocha');
@@ -42,8 +41,6 @@ var runSequence = require('run-sequence');
 var templateCache = require('gulp-angular-templatecache');
 var uglify = require('gulp-uglify');
 var usemin = require('gulp-usemin');
-var appendData = require('gulp-append-data');
-var consolidate = require('gulp-consolidate');
 
 /**
  * Delete the build directory

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
   "dependencies": {
     "async": "2.1.4",
     "basic-auth": "1.1.0",
-    "big-integer": "latest",
+    "big-integer": "1.6.23",
     "body-parser": "1.17.1",
     "bower": "1.8.0",
     "bunyan": "1.8.10",
     "bunyan-prettystream": "0.1.3",
+    "caliperjs": "git@github.com:sandeepmjay/caliper-js.git#develop",
     "config": "1.25.1",
     "cookie": "0.3.1",
     "cookie-parser": "1.4.3",
-    "dtrace-provider": "0.8.1",
     "event-stream": "3.3.4",
     "del": "2.2.2",
     "ejs": "2.5.5",
@@ -34,12 +34,9 @@
     "gulp": "3.9.1",
     "gulp-add-src": "0.2.0",
     "gulp-angular-templatecache": "2.0.0",
-    "gulp-append-data": "latest",
-    "gulp-consolidate": "latest",
     "gulp-csslint": "1.0.0",
     "gulp-cssmin": "0.1.7",
     "gulp-filter": "5.0.0",
-    "gulp-imagemin": "3.1.1",
     "gulp-eslint": "3.0.1",
     "gulp-htmlmin": "3.0.0",
     "gulp-mocha": "3.0.1",
@@ -54,6 +51,7 @@
     "mime": "1.3.4",
     "moment": "2.18.1",
     "moment-timezone": "0.5.11",
+    "nan": "2.5.1",
     "oauth": "0.9.15",
     "pg": "6.1.5",
     "randomstring": "1.1.5",
@@ -61,13 +59,12 @@
     "restjsdoc": "0.0.7",
     "run-sequence": "1.2.2",
     "sequelize": "3.30.4",
-    "swig": "latest",
     "tincanjs": "0.50.0",
     "uuid": "3.0.1",
     "xapi-validator": "git@github.com:ets-berkeley-edu/xapi-validator.git",
     "yargs": "7.0.2"
   },
   "engines": {
-    "node": "6.9.1"
+    "node": "6.10.0"
   }
 }


### PR DESCRIPTION
Added github SSH keys configuration under ebextensions for node environment to resolve private package dependencies. The SSH keys are made available under an S3 bucket requiring authentication. The git configurations for Elastic Beanstalk downloads the keys and adds it to the .ssh folder. All of these tasks need to be performed as a root user (Not as ec-user or node user).

Also, migrated cloud-lrs to node 6.10.0 and updated package.json to mitigate npm install errors on elastic beanstalk.

Bunyan was updated to latest version 2.0.0. Bunyan uses dtrace-provider as a dependency which in turn refers nan(2.6.2). The latest version of nan was causing npm install errors. Nan has been downgrade to 2.5.1.

Removed gulp-imagemin, gulp-append-data, gulp-consolidate packages as LRS is not using them. imagemin requires a dependency called gifsicle(3.0.4) which results in npm install errors.  
