### PR TITLE
[LA-101] Switching from classic to application load balancer

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -11,93 +11,58 @@ packages:
     mod24_ssl: []
 
 option_settings:
-  # Application health checks must be made over SSL.
-  aws:elasticbeanstalk:application:
-    Application Healthcheck URL: HTTPS:443/
-
+  # Defines node environment details for elastic beanstalk
   aws:elasticbeanstalk:container:nodejs:
     NodeVersion: 6.10.0
     ProxyServer: apache
     NodeCommand: 'node app'
 
-  # The load balancer listens on a secure connection, decrypts to do its work, and re-encrypts for a secure
-  # connection to EC2 instances.
-  aws:elb:listener:443:
-    SSLCertificateId: arn:aws:acm:us-west-2:697877139013:certificate/a50eaef4-d167-40eb-a834-7e071d88650f
-    ListenerProtocol: HTTPS
-    InstancePort: 443
-    InstanceProtocol: HTTPS
+  # Defines launch configurations for the environment and auto scaling group
+  aws:autoscaling:launchconfiguration:
+    InstanceType: t2.micro
+    EC2KeyName: cloudlrs-aws-eb
+    IamInstanceProfile: aws-elasticbeanstalk-ec2-role
 
-  aws:elb:loadbalancer:
-    SecurityGroups: '`{ "Ref" : "loadbalancersg" }`'
-    ManagedSecurityGroup: '`{ "Ref" : "loadbalancersg" }`'
+  # Load Balancer configurations
+  aws:elasticbeanstalk:environment:
+    LoadBalancerType: application
+    ServiceRole: aws-elasticbeanstalk-service-role
 
-  aws:elb:policies:backendencryption:
-    PublicKeyPolicyNames: backendkey
-    InstancePorts: 443
+  # Disable the load balancer's default listener on port 80.
+  aws:elbv2:listener:default:
+    ListenerEnabled: 'false'
 
-  # The load balancer expects this public key on the EC2 instances (see 01_create_apache_conf.config).
-  aws:elb:policies:backendkey:
-    PublicKey: |
-      -----BEGIN CERTIFICATE-----
-      MIIEIjCCAwoCCQCwhQUqTb0YaDANBgkqhkiG9w0BAQUFADCB0jELMAkGA1UEBhMC
-      VVMxEzARBgNVBAgTCkNhbGlmb3JuaWExETAPBgNVBAcTCEJlcmtlbGV5MSEwHwYD
-      VQQKExhVbml2ZXJzaXR5IG9mIENhbGlmb3JuaWExKDAmBgNVBAsTH0VkdWNhdGlv
-      bmFsIFRlY2hub2xvZ3kgU2VydmljZXMxIDAeBgNVBAMTF2V0cy1iZXJrZWxleS1z
-      dWl0ZWMubmV0MSwwKgYJKoZIhvcNAQkBFh1hd3Mtc3VpdGVjQGxpc3RzLmJlcmtl
-      bGV5LmVkdTAeFw0xNzAxMzAyMTMyNDFaFw0xODAxMzAyMTMyNDFaMIHSMQswCQYD
-      VQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTERMA8GA1UEBxMIQmVya2VsZXkx
-      ITAfBgNVBAoTGFVuaXZlcnNpdHkgb2YgQ2FsaWZvcm5pYTEoMCYGA1UECxMfRWR1
-      Y2F0aW9uYWwgVGVjaG5vbG9neSBTZXJ2aWNlczEgMB4GA1UEAxMXZXRzLWJlcmtl
-      bGV5LXN1aXRlYy5uZXQxLDAqBgkqhkiG9w0BCQEWHWF3cy1zdWl0ZWNAbGlzdHMu
-      YmVya2VsZXkuZWR1MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmiwl
-      d0KYQsyPczI9NYX9+lywQOU4jUFuls/VyN/WV9iwNYnIe3PI2kGcuVjwGNA2c1NK
-      WAjFUH4Ylbv0UjbXE2kPTIP7haJ+MzOWIuRP6xMyh6VBbw58y91btmDBts1KxeFt
-      uho2SQ/K6W+obZRAAGvwy//ejL5H5KU9MDhFSfhvr1Obo5Dl4KtJ6Q3RyM33PUxl
-      vFUUSyJq15vFkTS2081Ezj6grP4rDSwgWPpe3Nx7Qij1tbnWsNUhq34BiKUlTGo+
-      3zks+y0CRs2vqFBbBbziHc7T6sXi5hf9FpIw1fDY08a7bdJ96oDKX79UuAWwoK2E
-      AFeE8pPnAcpNq/BrrQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQAXm7iNjbbmA0hm
-      pYmatH7rYyt3x/cMIPk+JqAE5Wl7LX3AWs+VJUEQfmx7eH/OlIuH1DZG0JYELmDw
-      yf0os30rNk1zz4+HT6+QdkikqVXWLljK3/F2UcLRQ1QxAUhhQZyjEA0S/QCeA+Um
-      qQQ3IN3HNqsQtW2s9lZh3lULtjQPjiaxA0bHE7wpfDqZ7/3pqYVqDbDgSea7KK7a
-      dlAHiyP7+LP4U00bQp/m1Hb5ykT/rLMjiVwqFpB+YjCsUsuPYq1UTLNA2zh7mvJP
-      BhNKFR9+k+Kpl9YBcbLGoC67OPLjPUIdrBLu660JInFuItCiiq6w4aLBPUDGblgy
-      8JH5mCAF
-      -----END CERTIFICATE-----
+  # Enable a custom load balancer listener on port 433.
+  aws:elbv2:listener:443:
+    ListenerEnabled: 'true'
+    Protocol: HTTPS
+    SSLCertificateArns: arn:aws:acm:us-west-2:697877139013:certificate/a50eaef4-d167-40eb-a834-7e071d88650f
+
+  aws:elasticbeanstalk:healthreporting:system:
+    SystemType: enhanced
+
+  aws:elasticbeanstalk:command:
+    DeploymentPolicy: Immutable
+    Timeout: 3600
+
+  # Log publication and monitoring options
+  aws:elasticbeanstalk:hostmanager:
+    LogPublicationControl: 'true'
+
+  aws:elasticbeanstalk:cloudwatch:logs:
+    StreamLogs: true
+    DeleteOnTerminate: false
+    RetentionInDays: 180
+
+  aws:elasticbeanstalk:xray:
+    XRayEnabled: 'true'
+
+  # Instances talk to the load balancer over HTTPS..
+  aws:elasticbeanstalk:application:
+    Application Healthcheck URL: HTTPS:443/
 
 Resources:
-  # The load balancer listens on port 443 from any source.
-  loadbalancersg:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: load balancer security group
-      VpcId: vpc-b3a99ed6
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIp: 0.0.0.0/0
-
-  # The load balancer initiates connections on port 443 only to destinations in the EC2 instance security group.
-  httpsToBackendInstances:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      GroupId: {"Fn::GetAtt" : ["loadbalancersg", "GroupId"]}
-      IpProtocol: tcp
-      ToPort: 443
-      FromPort: 443
-      DestinationSecurityGroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
-
-  # EC2 instances accept connections on port 443 only from the load balancer.
-  httpsFromLoadBalancerSG:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
-      IpProtocol: tcp
-      ToPort: 443
-      FromPort: 443
-      SourceSecurityGroupId: {"Fn::GetAtt" : ["loadbalancersg", "GroupId"]}
-
+  # Instances may download protected files from a private S3 bucket.
   AWSEBAutoScalingGroup:
     Metadata:
       AWS::CloudFormation::Authentication:

--- a/node_modules/lrs-course/lib/api.js
+++ b/node_modules/lrs-course/lib/api.js
@@ -62,13 +62,13 @@ var getOrCreateCourse = module.exports.getOrCreateCourse = function(canvasCourse
     return callback({'code': 400, 'msg': validationResult.error.details[0].message});
   }
 
-  // Get the course from the DB or create it if it doesn't exist yet
+  // Get the course for a particular tenant from the DB or create it if it doesn't exist yet
   options = {
     'where': {
-      'canvas_course_id': canvasCourseId
+      'canvas_course_id': canvasCourseId,
+      'tenant_id': canvas.id
     },
     'defaults': {
-      'tenant_id': canvas.id,
       'name': courseInfo.name,
       'privacydashboard_url': courseInfo.privacydashboard_url
     }


### PR DESCRIPTION
Switch from classic load balancer to application load balancer. Added configs 
 - Log publishing (S3 & Cloudwatch) 
- X-ray monitoring 
- Enhanced health monitoring.
- Updates & Deployments policy is set to Immutable
- Autoscale launch configuration Instance types

Some tidbits:
For load balancer changes via eb configs defining ec2-service-role is required. The policy needs to be set up for the IAM roles.  

Instance types needs to be defined as a part of eb create command(eb create -i t2.medium). Alternatively, these can be changed using eb config file. For subsequent changes launch configurations can be defined in the autoscale group.

