### PR TITLE
LA-40 - First pass on Codepipeline set up for cloud-lrs

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,29 @@
+version: 0.1
+
+eb_codebuild_settings:
+  CodeBuildServiceRole: arn:aws:iam::697877139013:role/service-role/codebuild-LRS-service-role
+  ComputeType: Linux
+  Image: aws/codebuild/nodejs:6.3.1
+  Timeout: 60
+
+phases:
+  install:
+    commands:
+      - echo "npm install"
+  pre_build:
+    commands:
+      - echo "./node_modules/.bin/gulp eslint"
+  build:
+    commands:
+      - echo "build phase"
+  post_build:
+    commands:
+      - for i in $(ls node_modules | grep -v ^lrs-); do rm -Rf node_modules/$i; done
+
+artifacts:
+  files:
+    - '.bowerrc'
+    - '.ebextensions/*'
+    - '.elasticbeanstalk/*'
+    - '.gitignore'
+    - '**/*'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloud-lrs",
   "description": "Cloud-based Learning Record Store",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/ets-berkeley-edu/cloud-lrs.git"


### PR DESCRIPTION
Added buildspec.yml for Code pipeline integration. Updated cloud-lrs version in package.json

Code Build in AWS does not support Git+ssh. The private repo dependencies in package.json can't be resolved for this reason. Currently, using code pipeline as a way to streamline deployments. But, anything related to build, running mocha tests etc. are performed outside of Code pipeline(usually before pushing PR's. Travis support will be added to cloud-lrs).



 